### PR TITLE
Correctly assign kill data to mine defuser

### DIFF
--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -340,6 +340,11 @@ void UselessMine::Event (bz_EventData *eventData)
                             bz_sendTextMessagef(BZ_SERVER, playerID, "You were killed by %s's mine", owner);
                         }
                     }
+                    else
+                    {
+                        //if the owner was killed with their own mine, send a message
+                        bz_sendTextMessagef(BZ_SERVER, BZ_ALLUSERS, "%s was owned by their own mine!", owner);
+                    }
                 }
                 else if (mine.defused)
                 {

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -343,10 +343,13 @@ void UselessMine::Event (bz_EventData *eventData)
                 }
                 else if (mine.defused)
                 {
-                    dieData->killerID = mine.defuserID;
-
-                    if (playerID != mine.owner)
+                    // Make sure the killer was the server, and the victim was the owner.
+                    if (dieData->killerID == 253 && playerID == mine.owner)
                     {
+                        // Since the killer was the server, it was the defusal that killed the player. Thus,
+                        // give credit where credit is due.
+                        dieData->killerID = mine.defuserID;
+
                         if (!defusalMessages.empty())
                         {
                             // The random number used to fetch a random taunting defusal message
@@ -361,7 +364,7 @@ void UselessMine::Event (bz_EventData *eventData)
                             // Let the BD player know that they killed the owner
                             bz_sendTextMessagef(BZ_SERVER, mine.defuserID, "You defused %s's mine", owner);
 
-                            // Let the owner know that they killed the BD player
+                            // Let the owner know that they were killed by the BD player
                             bz_sendTextMessagef(BZ_SERVER, mine.owner, "You were killed by %s's mine defusal", bz_getPlayerCallsign(mine.defuserID));
                             
                         }

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -107,7 +107,7 @@ public:
 
             return false;
         }
-        
+
         // This sets the mine for defusal - the mine will trigger, but
         // will instead trigger at the location of the owner, with the
         // killer ID being that of the defuser.
@@ -142,7 +142,7 @@ public:
         }
         // This sets the mine for detonation - the mine will trigger,
         // killing the victim and setting the killer as the mine
-        // owner. 
+        // owner.
         bool detonate()
         {
             if (queuedRemoval)
@@ -221,12 +221,12 @@ void UselessMine::Init (const char* commandLine)
     bztk_registerCustomDoubleBZDB("_mineSafetyTime", 5.0);
 
     // Save the location of the file so we can reload after
-    
+
     // This expects two command line parameters: the death messages
-    // file and the defusal messages file. 
+    // file and the defusal messages file.
     bz_APIStringList cmdLineParams;
     cmdLineParams.tokenize(commandLine, ",");
-    
+
     if (cmdLineParams.size() == 2)
     {
         deathMessagesFile = cmdLineParams.get(0);
@@ -238,7 +238,7 @@ void UselessMine::Init (const char* commandLine)
         defusalMessagesFile = "";
         bz_debugMessagef(DEBUG_VERBOSITY, "WARNING :: Useless Mine :: No messages loaded");
     }
-    
+
     reloadDeathMessages();
     reloadDefusalMessages();
 
@@ -357,10 +357,10 @@ void UselessMine::Event (bz_EventData *eventData)
 
                         // Take note of the defuser's callsign
                         const char* defuser = bz_getPlayerCallsign(mine.defuserID);
-                        
+
                         if (playerID == mine.owner)
                         {
-                            
+
                             if (!defusalMessages.empty())
                             {
                                 // The random number used to fetch a random taunting defusal message


### PR DESCRIPTION
This fixes #15 

This also sends a message when the owner is killed by their own mine.