### PR TITLE
Use new bzfs server shot API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bztoolkit"]
-	path = bztoolkit
-	url = https://github.com/allejo/bztoolkit.git

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # UselessMine
 
 [![GitHub release](https://img.shields.io/github/release/allejo/UselessMine.svg)](https://github.com/allejo/UselessMine/releases/latest)
-![Minimum BZFlag Version](https://img.shields.io/badge/BZFlag-v2.4.4+-blue.svg)
-[![License](https://img.shields.io/github/license/allejo/UselessMine.svg)](https://github.com/allejo/UselessMine/blob/master/LICENSE.md)
+![Minimum BZFlag Version](https://img.shields.io/badge/BZFlag-v2.4.14+-blue.svg)
+[![License](https://img.shields.io/github/license/allejo/UselessMine.svg)](/LICENSE.md)
 
 A BZFlag plug-in that allows players to convert the Useless flag into mines to kill other players simply by typing '/mine' while carrying a Useless flag.
 
@@ -10,8 +10,7 @@ The [original plug-in](http://forums.bzflag.org/viewtopic.php?f=79&t=10340&p=103
 
 ## Compiling Requirements
 
-- BZFlag 2.4.4+
-- [bztoolkit](https://github.com/allejo/bztoolkit)
+- BZFlag 2.4.14+
 - C++11
 
 This plug-in follows [my standard instructions for compiling plug-ins](https://github.com/allejo/docs.allejo.io/wiki/BZFlag-Plug-in-Distribution).
@@ -20,10 +19,12 @@ This plug-in follows [my standard instructions for compiling plug-ins](https://g
 
 ### Loading the plug-in
 
-This plug-in accepts the path to a [text file](https://github.com/allejo/UselessMine/blob/master/UselessMine.deathMessages) containing death messages when loaded. If a text file is not given when loaded, no death messages will be announced when mines are exploded.
+This plug-in accepts the path to two text files containing [death](/UselessMine.deathMessages) and [defusal](/UselessMine.defuseMessages) messages, respectively, when loaded.
+
+Order matters when you're loading the plug-in, it must be death messages before defuse messages. If you'd like to skip death messages and only have defuseMessages, you may use the keyword `NULL` in place of a death messages file.
 
 ```
--loadplugin UselessMine.so,UselessMine.deathMessages,UselessMine.defuseMessages
+-loadplugin UselessMine.so[,UselessMine.deathMessages][,UselessMine.defuseMessages]
 ```
 
 ### Custom Flags
@@ -55,18 +56,19 @@ These custom BZDB variables must be used with `-setforced`, which sets BZDB vari
 | `/reload deathmessages`   |   setAll   | Reload the death messages                |
 | `/reload defusalmessages` |   setAll   | Reload the defusal messages              |
 
-### Custom Death Messages file
+### Custom Death/Defusal Messages file
 
-This is an optional file that will store all of the witty death messages announced when a player detonates a mine. If you would like death messages to be announced, you must give the plug-in the file.
+These are optional files that will store all of the witty death/defusal messages announced when a player detonates or defuses a mine. If you would like death/defusal messages to be announced, you must give the plug-in the file.
 
-In the file, each line is a separate death message. The supported placeholders are the following:
+In the file, each line is a separate death or defusal message. The supported placeholders are the following:
 
-- `%victim%` - The player who got killed by the mine
+- `%victim%` - The player who got killed by the mine; only available in death messages
 - `%owner%` - The player who placed the mine originally
+- `%defuser%` - The player who defused the mine; only available in defusal messages
 - `%minecount%` - The remaining amount of mines left on the field
 
-The order in which you use the placeholders doesn't matter and the placeholders can be used several times in the same death message. Both `%victim%` and `%owner%` are required for each death message; `%minecount%` is optional.
+The order in which you use the placeholders doesn't matter and the placeholders can be used several times in the same death message.
 
 ## License
 
-[MIT](https://github.com/allejo/UselessMine/blob/master/LICENSE.md)
+[MIT](/LICENSE.md)

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -217,10 +217,10 @@ void UselessMine::Init (const char* commandLine)
 
     if (!bz_BZDBItemExists("_mineSafetyTime"))
     {
-        bz_setBZDBDouble("_mineSafetyTime", 5.0);
+        bz_setBZDBInt("_mineSafetyTime", 5);
     }
 
-    bz_setDefaultBZDBDouble("_mineSafetyTime", 5.0);
+    bz_setDefaultBZDBInt("_mineSafetyTime", 5);
 
     // Save the location of the file so we can reload after
 
@@ -350,7 +350,7 @@ void UselessMine::Event (bz_EventData *eventData)
             bz_PlayerUpdateEventData_V1* updateData = (bz_PlayerUpdateEventData_V1*)eventData;
 
             int playerID = updateData->playerID;
-            bool bypassSafetyTime = (playerSpawnTime[playerID] + bz_getBZDBDouble("_mineSafetyTime") <= bz_getCurrentTime());
+            bool bypassSafetyTime = (playerSpawnTime[playerID] + bz_getBZDBInt("_mineSafetyTime") <= bz_getCurrentTime());
             bz_BasePlayerRecord *pr = bz_getPlayerByIndex(playerID);
 
             bz_debugMessagef(DEBUG_VERBOSITY, "DEBUG :: Useless Mine :: player #%d at {%0.2f, %0.2f, %0.2f}",

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -184,6 +184,8 @@ private:
     std::string deathMessagesFile; // The path to the file containing death messages
     std::string defusalMessagesFile; // The path to the file containing defusal messages
     double playerSpawnTime[256]; // The time a player spawned last; used for _mineSafetyTime calculations
+
+    const char* bzdb_safetyTime = "_mineSafetyTime";
 };
 
 BZ_PLUGIN(UselessMine)
@@ -215,12 +217,7 @@ void UselessMine::Init (const char* commandLine)
 
     bz_RegisterCustomFlag("BD", "Bomb Defusal", "Safely defuse enemy mines while killing the mine owners", 0, eGoodFlag);
 
-    if (!bz_BZDBItemExists("_mineSafetyTime"))
-    {
-        bz_setBZDBInt("_mineSafetyTime", 5);
-    }
-
-    bz_setDefaultBZDBInt("_mineSafetyTime", 5);
+    bz_registerCustomBZDBInt(bzdb_safetyTime, 5);
 
     // Save the location of the file so we can reload after
 
@@ -271,6 +268,8 @@ void UselessMine::Cleanup (void)
     bz_removeCustomSlashCommand("minecount");
     bz_removeCustomSlashCommand("minestats");
     bz_removeCustomSlashCommand("reload");
+
+    bz_removeCustomBZDBVariable(bzdb_safetyTime);
 }
 
 void UselessMine::Event (bz_EventData *eventData)
@@ -350,7 +349,7 @@ void UselessMine::Event (bz_EventData *eventData)
             bz_PlayerUpdateEventData_V1* updateData = (bz_PlayerUpdateEventData_V1*)eventData;
 
             int playerID = updateData->playerID;
-            bool bypassSafetyTime = (playerSpawnTime[playerID] + bz_getBZDBInt("_mineSafetyTime") <= bz_getCurrentTime());
+            bool bypassSafetyTime = (playerSpawnTime[playerID] + bz_getBZDBInt(bzdb_safetyTime) <= bz_getCurrentTime());
             bz_BasePlayerRecord *pr = bz_getPlayerByIndex(playerID);
 
             bz_debugMessagef(DEBUG_VERBOSITY, "DEBUG :: Useless Mine :: player #%d at {%0.2f, %0.2f, %0.2f}",

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <map>
 #include <memory>
 #include <stdlib.h>
 
@@ -74,7 +75,7 @@ public:
             defused(false),
             detonated(false)
         {
-            uid.format("%d_%d_%d", owner, bz_getCurrentTime(), bzfrand());
+            uid.format("%d_%d_%d", owner, bz_getCurrentTime(), rand() % 32);
         }
 
         bool isStale()

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2013-2017 Vladimir "allejo" Jimenez
+    Copyright (C) 2013-2018 Vladimir "allejo" Jimenez
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the “Software”), to deal
@@ -35,7 +35,7 @@ const std::string PLUGIN_NAME = "Useless Mine";
 
 // Define plugin version numbering
 const int MAJOR = 1;
-const int MINOR = 1;
+const int MINOR = 2;
 const int REV = 0;
 const int BUILD = 84;
 
@@ -198,7 +198,9 @@ const char* UselessMine::Name (void)
     static std::string pluginName;
 
     if (pluginName.empty())
-        pluginName = bztk_pluginName(PLUGIN_NAME, MAJOR, MINOR, REV, BUILD);
+    {
+        pluginName = bz_format("%s %d.%d.%d (%d)", PLUGIN_NAME.c_str(), MAJOR, MINOR, REV, BUILD);
+    }
 
     return pluginName.c_str();
 }

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -23,8 +23,6 @@
 #include <algorithm>
 #include <functional>
 #include <map>
-#include <memory>
-#include <stdlib.h>
 
 #include "bzfsAPI.h"
 #include "plugin_files.h"
@@ -44,11 +42,11 @@ const int BUILD = 84;
 class UselessMine : public bz_Plugin, public bz_CustomSlashCommandHandler
 {
 public:
-    virtual const char* Name ();
-    virtual void Init (const char* config);
-    virtual void Event (bz_EventData *eventData);
-    virtual void Cleanup (void);
-    virtual bool SlashCommand (int, bz_ApiString, bz_ApiString, bz_APIStringList*);
+    virtual const char* Name();
+    virtual void Init(const char* config);
+    virtual void Event(bz_EventData *eventData);
+    virtual void Cleanup(void);
+    virtual bool SlashCommand(int, bz_ApiString, bz_ApiString, bz_APIStringList*);
 
     typedef std::multimap< int, std::string, std::greater<int> > rmap;
 
@@ -65,7 +63,7 @@ public:
         bool defused;          // True if the mine was defused with a Bomb Defusal flag
         bool detonated;        // True if the mine was detonated by a player
 
-        Mine (int _owner, float _pos[3], bz_eTeamType _team) :
+        Mine(int _owner, float _pos[3], bz_eTeamType _team) :
             owner(_owner),
             defuserID(-1),
             x(_pos[0]),
@@ -167,17 +165,19 @@ public:
     };
 
 private:
-    int  getMineCount ();
-    void loadConfiguration(const char* commandline),
-         reloadDeathMessages (),
-         reloadDefusalMessages (),
-         removePlayerMines (int playerID),
-         removeMine (Mine &mine),
-         sendDefuseMessage (int defuserID, int mineOwnerID, int victimID),
-         sendDeathMessage (int mineOwner, int victimID),
-         setMine (int owner, float pos[3], bz_eTeamType team);
-    std::string formatMineMessage (std::string msg, std::string mineOwner, std::string defuserOrVictim),
-                parsePath(bz_ApiString path);
+    int getMineCount();
+
+    void loadConfiguration(const char* commandline);
+    void reloadDeathMessages();
+    void reloadDefusalMessages();
+    void removePlayerMines(int playerID);
+    void removeMine(Mine &mine);
+    void sendDefuseMessage(int defuserID, int mineOwnerID, int victimID);
+    void sendDeathMessage(int mineOwner, int victimID);
+    void setMine(int owner, float pos[3], bz_eTeamType team);
+
+    const char* formatMineMessage(std::string msg, std::string mineOwner, std::string defuserOrVictim);
+    const char* parsePath(bz_ApiString path);
 
     std::vector<std::string> deathMessages; // A vector that will store all of the witty death messages
     std::vector<std::string> defusalMessages; // A vector that will store all of the witty defusal messages
@@ -192,7 +192,7 @@ private:
 
 BZ_PLUGIN(UselessMine)
 
-const char* UselessMine::Name (void)
+const char* UselessMine::Name(void)
 {
     static std::string pluginName;
 
@@ -204,7 +204,7 @@ const char* UselessMine::Name (void)
     return pluginName.c_str();
 }
 
-void UselessMine::Init (const char* commandLine)
+void UselessMine::Init(const char* commandLine)
 {
     Register(bz_eFlagGrabbedEvent);
     Register(bz_ePlayerDieEvent);
@@ -245,7 +245,7 @@ void UselessMine::Init (const char* commandLine)
     }
 }
 
-void UselessMine::Cleanup (void)
+void UselessMine::Cleanup(void)
 {
     Flush();
 
@@ -257,7 +257,7 @@ void UselessMine::Cleanup (void)
     bz_removeCustomBZDBVariable(bzdb_safetyTime);
 }
 
-void UselessMine::Event (bz_EventData *eventData)
+void UselessMine::Event(bz_EventData *eventData)
 {
     switch (eventData->eventType)
     {
@@ -462,7 +462,7 @@ bool UselessMine::SlashCommand(int playerID, bz_ApiString command, bz_ApiString 
 }
 
 // A function to format death messages in order to replace placeholders with callsigns and values
-std::string UselessMine::formatMineMessage(std::string msg, std::string mineOwner, std::string defuserOrVictim)
+const char* UselessMine::formatMineMessage(std::string msg, std::string mineOwner, std::string defuserOrVictim)
 {
     bz_ApiString formattedMessage = msg;
     formattedMessage.replaceAll("%owner%", mineOwner.c_str());
@@ -470,7 +470,7 @@ std::string UselessMine::formatMineMessage(std::string msg, std::string mineOwne
     formattedMessage.replaceAll("%defuser%", defuserOrVictim.c_str());
     formattedMessage.replaceAll("%minecount%", std::to_string(getMineCount()).c_str());
 
-    return formattedMessage;
+    return formattedMessage.c_str();
 }
 
 void UselessMine::sendDefuseMessage(int defuserID, int mineOwnerID, int victimID)
@@ -496,7 +496,7 @@ void UselessMine::sendDefuseMessage(int defuserID, int mineOwnerID, int victimID
 
             // Get a random defusal message
             std::string defusalMessage = defusalMessages.at(randomNumber);
-            bz_sendTextMessage(BZ_SERVER, BZ_ALLUSERS, formatMineMessage(defusalMessage, mineOwnerCallsign, defuserCallsign).c_str());
+            bz_sendTextMessage(BZ_SERVER, BZ_ALLUSERS, formatMineMessage(defusalMessage, mineOwnerCallsign, defuserCallsign));
         }
     }
     else
@@ -531,7 +531,7 @@ void UselessMine::sendDeathMessage(int mineOwner, int victimID)
 
         const char* mineVictimCallsign = bz_getPlayerCallsign(victimID);
 
-        bz_sendTextMessage(BZ_SERVER, BZ_ALLUSERS, formatMineMessage(deathMessage, mineOwnerCallsign, mineVictimCallsign).c_str());
+        bz_sendTextMessage(BZ_SERVER, BZ_ALLUSERS, formatMineMessage(deathMessage, mineOwnerCallsign, mineVictimCallsign));
     }
 }
 
@@ -555,7 +555,7 @@ void UselessMine::loadConfiguration(const char *commandline)
     }
 }
 
-std::string UselessMine::parsePath(bz_ApiString path)
+const char* UselessMine::parsePath(bz_ApiString path)
 {
     std::string lower = bz_tolower(path.c_str());
 
@@ -564,7 +564,7 @@ std::string UselessMine::parsePath(bz_ApiString path)
         return "";
     }
 
-    return path;
+    return path.c_str();
 }
 
 // Reload the death messages

--- a/UselessMine.cpp
+++ b/UselessMine.cpp
@@ -482,7 +482,7 @@ std::string UselessMine::formatMineMessage(std::string msg, std::string mineOwne
     bz_ApiString formattedMessage = msg;
     formattedMessage.replaceAll("%owner%", mineOwner.c_str());
     formattedMessage.replaceAll("%victim%", defuserOrVictim.c_str());
-    formattedMessage.replaceAll("%defuser", defuserOrVictim.c_str());
+    formattedMessage.replaceAll("%defuser%", defuserOrVictim.c_str());
     formattedMessage.replaceAll("%minecount%", std::to_string(getMineCount()).c_str());
 
     return formattedMessage;


### PR DESCRIPTION
**Task List**

- [x] Removes bztoolkit dependency
- [x] Uses new `bz_fireServerShot()` function (see: https://github.com/BZFlag-Dev/bzflag/pull/99)
- [x] Bump minimum bzfs to 2.4.14
- [x] Remove bztoolkit dep from README
- [x] Test mines and bomb defusal flag
- [x] Allow "defuseMessages" file to be optional in the
- [x] Accept keyword "NULL" as a file path